### PR TITLE
HttpClient Host Header

### DIFF
--- a/HttpClient.cpp
+++ b/HttpClient.cpp
@@ -176,7 +176,14 @@ int HttpClient::sendInitialHeaders(const char* aServerName, IPAddress aServerIP,
     // The host header, if required
     if (aServerName)
     {
-        sendHeader("Host", aServerName);
+        iClient->print("Host: ");
+        iClient->print(aServerName);
+        if (aPort != kHttpPort)
+        {
+          iClient->print(":");
+          iClient->print(aPort);
+        }
+        iClient->println();
     }
     // And user-agent string
     iClient->print("User-Agent: ");


### PR DESCRIPTION
I thought I'd come across a bug in the HttpClient library, then I wasn't so sure, but now I think I can probably class it as a bug after all.

Specifically, when sending the host header it doesn't send the port number. Now in my code, as I'm using:

int HttpClient::startRequest(const IPAddress& aServerAddress, const char\* aServerName, uint16_t aServerPort, const char\* aURLPath, const char\* aHttpMethod, const char\* aUserAgent)

You could say that I should pass the port number in aServerName, but then if you're using:

int HttpClient::startRequest(const char\* aServerName, uint16_t aServerPort, const char\* aURLPath, const char\* aHttpMethod, const char\* aUserAgent)

If you pass a port number in there other than 80 it still doesn't get sent. Also with the variable being called aServerName rather than "Host" I do think it's correct (and, of course, easier :) that HttpClient would send the port.
