### PR TITLE
fixed http version 1.0

### DIFF
--- a/HttpClient.cpp
+++ b/HttpClient.cpp
@@ -11,7 +11,6 @@
 #include <ctype.h>
 
 // Initialize constants
-const char* HttpClient::kUserAgent = "Arduino/2.0";
 const char* HttpClient::kGet = "GET";
 const char* HttpClient::kPost = "POST";
 const char* HttpClient::kPut = "PUT";
@@ -187,14 +186,10 @@ int HttpClient::sendInitialHeaders(const char* aServerName, IPAddress aServerIP,
         iClient->println();
     }
     // And user-agent string
-    iClient->print("User-Agent: ");
     if (aUserAgent)
     {
+        iClient->print("User-Agent: ");
         iClient->println(aUserAgent);
-    }
-    else
-    {
-        iClient->println(kUserAgent);
     }
 
     // Everything has gone well

--- a/HttpClient.cpp
+++ b/HttpClient.cpp
@@ -173,7 +173,7 @@ int HttpClient::sendInitialHeaders(const char* aServerName, IPAddress aServerIP,
       }
     }
     iClient->print(aURLPath);
-    iClient->println(" HTTP/1.1");
+    iClient->println(" HTTP/1.0");
     // The host header, if required
     if (aServerName)
     {

--- a/HttpClient.cpp
+++ b/HttpClient.cpp
@@ -44,7 +44,7 @@ void HttpClient::resetState()
 {
   iState = eIdle;
   iStatusCode = 0;
-  iContentLength = 0;
+  iContentLength = kNoContentLengthHeader;
   iBodyLengthConsumed = 0;
   iContentLengthPtr = kContentLengthPrefix;
   iHttpResponseTimeout = kHttpResponseTimeout;
@@ -451,7 +451,7 @@ int HttpClient::read()
     int ret = iClient->read();
     if (ret >= 0)
     {
-        if (endOfHeadersReached() && iContentLength > 0)
+        if (endOfHeadersReached() && iContentLength > kNoContentLengthHeader)
 	{
             // We're outputting the body now and we've seen a Content-Length header
             // So keep track of how many bytes are left
@@ -465,7 +465,7 @@ int HttpClient::read()
 int HttpClient::read(uint8_t *buf, size_t size)
 {
     int ret =iClient->read(buf, size);
-    if (endOfHeadersReached() && iContentLength > 0)
+    if (endOfHeadersReached() && iContentLength > kNoContentLengthHeader)
     {
         // We're outputting the body now and we've seen a Content-Length header
         // So keep track of how many bytes are left
@@ -503,8 +503,6 @@ int HttpClient::readHeader()
             {
                 // We've reached the end of the prefix
                 iState = eReadingContentLength;
-                // Just in case we get multiple Content-Length headers, this
-                // will ensure we just get the value of the last one
                 iContentLength = 0;
             }
         }

--- a/HttpClient.cpp
+++ b/HttpClient.cpp
@@ -46,7 +46,7 @@ void HttpClient::resetState()
   iStatusCode = 0;
   iContentLength = 0;
   iBodyLengthConsumed = 0;
-  iContentLengthPtr = 0;
+  iContentLengthPtr = kContentLengthPrefix;
   iHttpResponseTimeout = kHttpResponseTimeout;
 }
 

--- a/HttpClient.h
+++ b/HttpClient.h
@@ -28,7 +28,6 @@ class HttpClient : public Client
 public:
     static const int kNoContentLengthHeader =-1;
     static const int kHttpPort =80;
-    static const char* kUserAgent;
     static const char* kGet;
     static const char* kPost;
     static const char* kPut;
@@ -60,8 +59,7 @@ public:
                           "Host" header line won't be sent
       @param aServerPort  Port to connect to on the server
       @param aURLPath     Url to request
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int get(const char* aServerName, uint16_t aServerPort, const char* aURLPath, 
@@ -72,8 +70,7 @@ public:
       @param aServerName  Name of the server being connected to.  If NULL, the
                           "Host" header line won't be sent
       @param aURLPath     Url to request
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int get(const char* aServerName, const char* aURLPath, const char* aUserAgent =NULL)
@@ -86,8 +83,7 @@ public:
                             "Host" header line won't be sent
       @param aServerPort    Port to connect to on the server
       @param aURLPath       Url to request
-      @param aUserAgent     User-Agent string to send.  If NULL the default
-                            user-agent kUserAgent will be sent
+      @param aUserAgent     User-Agent string to send.
       @return 0 if successful, else error
     */
     int get(const IPAddress& aServerAddress,
@@ -103,8 +99,7 @@ public:
       @param aServerName    Name of the server being connected to.  If NULL, the
                             "Host" header line won't be sent
       @param aURLPath       Url to request
-      @param aUserAgent     User-Agent string to send.  If NULL the default
-                            user-agent kUserAgent will be sent
+      @param aUserAgent     User-Agent string to send.
       @return 0 if successful, else error
     */
     int get(const IPAddress& aServerAddress,
@@ -118,8 +113,7 @@ public:
                           "Host" header line won't be sent
       @param aServerPort  Port to connect to on the server
       @param aURLPath     Url to request
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int post(const char* aServerName, 
@@ -132,8 +126,7 @@ public:
       @param aServerName  Name of the server being connected to.  If NULL, the
                           "Host" header line won't be sent
       @param aURLPath     Url to request
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int post(const char* aServerName, 
@@ -148,8 +141,7 @@ public:
                           "Host" header line won't be sent
       @param aServerPort  Port to connect to on the server
       @param aURLPath     Url to request
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int post(const IPAddress& aServerAddress,
@@ -165,8 +157,7 @@ public:
       @param aServerName  Name of the server being connected to.  If NULL, the
                           "Host" header line won't be sent
       @param aURLPath     Url to request
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int post(const IPAddress& aServerAddress,
@@ -180,8 +171,7 @@ public:
                           "Host" header line won't be sent
       @param aServerPort  Port to connect to on the server
       @param aURLPath     Url to request
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int put(const char* aServerName, 
@@ -194,8 +184,7 @@ public:
       @param aServerName  Name of the server being connected to.  If NULL, the
                           "Host" header line won't be sent
       @param aURLPath     Url to request
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int put(const char* aServerName, 
@@ -210,8 +199,7 @@ public:
                           "Host" header line won't be sent
       @param aServerPort  Port to connect to on the server
       @param aURLPath     Url to request
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int put(const IPAddress& aServerAddress,
@@ -227,8 +215,7 @@ public:
       @param aServerName  Name of the server being connected to.  If NULL, the
                           "Host" header line won't be sent
       @param aURLPath     Url to request
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int put(const IPAddress& aServerAddress,
@@ -242,8 +229,7 @@ public:
       @param aServerPort  Port to connect to on the server
       @param aURLPath     Url to request
       @param aHttpMethod  Type of HTTP request to make, e.g. "GET", "POST", etc.
-      @param aUserAgent   User-Agent string to send.  If NULL the default
-                          user-agent kUserAgent will be sent
+      @param aUserAgent   User-Agent string to send.
       @return 0 if successful, else error
     */
     int startRequest(const char* aServerName,
@@ -259,8 +245,7 @@ public:
       @param aServerPort  Port to connect to on the server
       @param aURLPath	Url to request
       @param aHttpMethod  Type of HTTP request to make, e.g. "GET", "POST", etc.
-      @param aUserAgent User-Agent string to send.  If NULL the default
-                        user-agent kUserAgent will be sent
+      @param aUserAgent User-Agent string to send.
       @return 0 if successful, else error
     */
     int startRequest(const IPAddress& aServerAddress,
@@ -387,8 +372,7 @@ protected:
       @param aServerPort  Port of the server being connected to.
       @param aURLPath	Url to request
       @param aHttpMethod  Type of HTTP request to make, e.g. "GET", "POST", etc.
-      @param aUserAgent User-Agent string to send.  If NULL the default
-                        user-agent kUserAgent will be sent
+      @param aUserAgent User-Agent string to send.
       @return 0 if successful, else error
     */
     int sendInitialHeaders(const char* aServerName,


### PR DESCRIPTION
When sending HTTP/1.1, chunked encoding may occur. With version being 1.0, this usually doesn't happen. This is also commented above the sendInitialHeaders function but for some reason is 1.1.
thx