### PR TITLE
Added default case

### DIFF
--- a/HttpClient.cpp
+++ b/HttpClient.cpp
@@ -358,6 +358,10 @@ int HttpClient::responseStatusCode()
                     case eStatusCodeRead:
                         // We're just waiting for the end of the line now
                         break;
+				    
+		    default:
+			// Do nothing
+			break;
                     };
                     // We read something, reset the timeout counter
                     timeoutStart = millis();


### PR DESCRIPTION
Added default case to suppress -Wswitch warnings while compiling under PlatformIO.
(platform: atmelavr; board: uno; framework: arduino)